### PR TITLE
feat: add option to disable automatic session switching

### DIFF
--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -110,6 +110,9 @@ impl Pomo {
                     }
                 }
 
+                (AppScreen::Timer, KeyCode::Char('a')) => {
+                    self.auto_switch_sessions = !self.auto_switch_sessions
+                }
                 (AppScreen::Timer, KeyCode::Char('t')) => self.screen = AppScreen::Tasks,
                 (AppScreen::Timer, KeyCode::Char(' ')) => self.is_running = !self.is_running,
                 (AppScreen::Timer, KeyCode::Char('r')) => self.time_remaining = self.work_time,

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -18,6 +18,7 @@ impl Pomo {
             short_break_mins: self.short_break_time.as_secs() / 60,
             long_break_mins: self.long_break_time.as_secs() / 60,
             tasks: self.tasks.clone(),
+            auto_switch_sessions: self.auto_switch_sessions,
         };
 
         let toml = toml::to_string_pretty(&config)?;
@@ -42,6 +43,7 @@ impl Pomo {
                 app.short_break_time = Duration::from_secs(config.short_break_mins * 60);
                 app.long_break_time = Duration::from_secs(config.long_break_mins * 60);
                 app.tasks = config.tasks;
+                app.auto_switch_sessions = config.auto_switch_sessions;
                 app.reset_timer_to_mode();
             }
         }

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -35,14 +35,14 @@ impl Pomo {
         let mut app = Pomo::new();
         if let Some(proj_dirs) = ProjectDirs::from("", "", "pomoru") {
             let config_path = proj_dirs.config_dir().join("config.toml");
-            if let Ok(content) = fs::read_to_string(config_path) {
-                if let Ok(config) = toml::from_str::<Config>(&content) {
-                    app.work_time = Duration::from_secs(config.work_time_mins * 60);
-                    app.short_break_time = Duration::from_secs(config.short_break_mins * 60);
-                    app.long_break_time = Duration::from_secs(config.long_break_mins * 60);
-                    app.tasks = config.tasks;
-                    app.reset_timer_to_mode();
-                }
+            if let Ok(content) = fs::read_to_string(config_path)
+                && let Ok(config) = toml::from_str::<Config>(&content)
+            {
+                app.work_time = Duration::from_secs(config.work_time_mins * 60);
+                app.short_break_time = Duration::from_secs(config.short_break_mins * 60);
+                app.long_break_time = Duration::from_secs(config.long_break_mins * 60);
+                app.tasks = config.tasks;
+                app.reset_timer_to_mode();
             }
         }
         app
@@ -67,14 +67,13 @@ impl Pomo {
 
                 // Tighten poll to 16ms (~60fps feel) for input responsiveness
                 event_res = tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(16))) => {
-                    if let Ok(Ok(true)) = event_res {
-                        if let Ok(Event::Key(key)) = event::read() {
-                            if key.kind == event::KeyEventKind::Press {
-                                self.handle_key(key);
-                            }
-                        }
+                    if let Ok(Ok(true)) = event_res
+                        && let Ok(Event::Key(key)) = event::read()
+                        && key.kind == event::KeyEventKind::Press
+                    {
+                        self.handle_key(key);
                     }
-                }
+               }
             }
 
             if self.should_quit {

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -43,20 +43,20 @@ impl Default for Theme {
 
         if let Some(base_dirs) = BaseDirs::new() {
             let path = base_dirs.home_dir().join(".config/noctalia/colors.json");
-            if let Ok(content) = fs::read_to_string(&path) {
-                if let Ok(colors) = serde_json::from_str::<NoctaliaColors>(&content) {
-                    if let Some(c) = parse_hex_color(&colors.m_primary) {
-                        theme.primary = c;
-                    }
-                    if let Some(c) = parse_hex_color(&colors.m_on_surface_variant) {
-                        theme.overlay0 = c;
-                    }
-                    if let Some(c) = parse_hex_color(&colors.m_surface_variant) {
-                        theme.surface0 = c;
-                    }
-                    if let Some(c) = parse_hex_color(&colors.m_on_surface) {
-                        theme.text = c;
-                    }
+            if let Ok(content) = fs::read_to_string(&path)
+                && let Ok(colors) = serde_json::from_str::<NoctaliaColors>(&content)
+            {
+                if let Some(c) = parse_hex_color(&colors.m_primary) {
+                    theme.primary = c;
+                }
+                if let Some(c) = parse_hex_color(&colors.m_on_surface_variant) {
+                    theme.overlay0 = c;
+                }
+                if let Some(c) = parse_hex_color(&colors.m_surface_variant) {
+                    theme.surface0 = c;
+                }
+                if let Some(c) = parse_hex_color(&colors.m_on_surface) {
+                    theme.text = c;
                 }
             }
         }
@@ -180,7 +180,7 @@ impl Pomo {
         match self.mode {
             SessionMode::Work => {
                 self.break_count += 1;
-                if self.break_count % 3 == 0 {
+                if self.break_count.is_multiple_of(3) {
                     self.mode = SessionMode::LongBreak;
                     self.time_remaining = self.long_break_time;
                     self.total_duration = self.long_break_time;

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -91,6 +91,7 @@ pub struct Config {
     pub short_break_mins: u64,
     pub long_break_mins: u64,
     pub tasks: Vec<Task>,
+    pub auto_switch_sessions: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -180,6 +180,7 @@ impl Pomo {
                 self.is_running = true;
             } else {
                 self.is_running = false;
+                self.reset_timer_to_mode();
             }
         }
     }

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -158,20 +158,21 @@ impl Pomo {
                 "Ref! Do Something! The break's over!",
             ];
 
+            // Use the remaining duration/break count as a seed for simple 'random' selection
+            let idx = (self.break_count as usize) % 4;
+
+            let (title, msg) = match self.mode {
+                SessionMode::Work => ("Focus Block Complete", focus_msg[idx]),
+                _ => ("Break Over", break_msg[idx]),
+            };
+
+            self.send_notification(title, msg);
+
             if self.auto_switch_sessions {
-                // Use the remaining duration/break count as a seed for simple 'random' selection
-                let idx = (self.break_count as usize) % 4;
-
-                let (title, msg) = match self.mode {
-                    SessionMode::Work => ("Focus Block Complete", focus_msg[idx]),
-                    _ => ("Break Over", break_msg[idx]),
-                };
-
-                self.send_notification(title, msg);
                 self.transition_next_session();
                 self.is_running = true;
             } else {
-                // TODO: Handle manual session switching
+                self.is_running = false;
             }
         }
     }

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -91,7 +91,13 @@ pub struct Config {
     pub short_break_mins: u64,
     pub long_break_mins: u64,
     pub tasks: Vec<Task>,
+
+    #[serde(default = "default_auto_switch")]
     pub auto_switch_sessions: bool,
+}
+
+fn default_auto_switch() -> bool {
+    true
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -40,15 +40,23 @@ impl Default for Theme {
             surface0: Color::Rgb(49, 50, 68),
             text: Color::Rgb(205, 214, 244),
         };
-        
+
         if let Some(base_dirs) = BaseDirs::new() {
             let path = base_dirs.home_dir().join(".config/noctalia/colors.json");
             if let Ok(content) = fs::read_to_string(&path) {
                 if let Ok(colors) = serde_json::from_str::<NoctaliaColors>(&content) {
-                    if let Some(c) = parse_hex_color(&colors.m_primary) { theme.primary = c; }
-                    if let Some(c) = parse_hex_color(&colors.m_on_surface_variant) { theme.overlay0 = c; }
-                    if let Some(c) = parse_hex_color(&colors.m_surface_variant) { theme.surface0 = c; }
-                    if let Some(c) = parse_hex_color(&colors.m_on_surface) { theme.text = c; }
+                    if let Some(c) = parse_hex_color(&colors.m_primary) {
+                        theme.primary = c;
+                    }
+                    if let Some(c) = parse_hex_color(&colors.m_on_surface_variant) {
+                        theme.overlay0 = c;
+                    }
+                    if let Some(c) = parse_hex_color(&colors.m_surface_variant) {
+                        theme.surface0 = c;
+                    }
+                    if let Some(c) = parse_hex_color(&colors.m_on_surface) {
+                        theme.text = c;
+                    }
                 }
             }
         }
@@ -101,6 +109,7 @@ pub struct Pomo {
     pub time_remaining: Duration,
     pub total_duration: Duration,
     pub is_running: bool,
+    pub auto_switch_sessions: bool,
     pub break_count: u32,
     pub tasks: Vec<Task>,
     pub task_state: ListState,
@@ -122,6 +131,7 @@ impl Pomo {
             time_remaining: work,
             total_duration: work,
             is_running: false,
+            auto_switch_sessions: true,
             break_count: 0,
             tasks: Vec::new(),
             task_state: ListState::default(),
@@ -148,17 +158,21 @@ impl Pomo {
                 "Ref! Do Something! The break's over!",
             ];
 
-            // Use the remaining duration/break count as a seed for simple 'random' selection
-            let idx = (self.break_count as usize) % 4;
+            if self.auto_switch_sessions {
+                // Use the remaining duration/break count as a seed for simple 'random' selection
+                let idx = (self.break_count as usize) % 4;
 
-            let (title, msg) = match self.mode {
-                SessionMode::Work => ("Focus Block Complete", focus_msg[idx]),
-                _ => ("Break Over", break_msg[idx]),
-            };
+                let (title, msg) = match self.mode {
+                    SessionMode::Work => ("Focus Block Complete", focus_msg[idx]),
+                    _ => ("Break Over", break_msg[idx]),
+                };
 
-            self.send_notification(title, msg);
-            self.transition_next_session();
-            self.is_running = true;
+                self.send_notification(title, msg);
+                self.transition_next_session();
+                self.is_running = true;
+            } else {
+                // TODO: Handle manual session switching
+            }
         }
     }
 

--- a/src/pomo/ui.rs
+++ b/src/pomo/ui.rs
@@ -130,25 +130,28 @@ fn render_session_dots(f: &mut Frame, app: &Pomo, area: Rect) {
     let spans = modes
         .iter()
         .enumerate()
-        .map(|(i, (mode, label))| {
+        .flat_map(|(i, (mode, label))| {
             let is_active = app.mode == *mode;
             let color = if is_active {
                 app.theme.primary
             } else {
                 app.theme.overlay0
             };
+
             let content = if is_active {
                 format!("• {}", label)
             } else {
                 label.to_string()
             };
+
             let mut s = vec![Span::styled(content, Style::default().fg(color))];
+
             if i < modes.len() - 1 {
                 s.push(Span::raw("     "));
             }
+
             s
         })
-        .flatten()
         .collect::<Vec<_>>();
 
     f.render_widget(

--- a/src/pomo/ui.rs
+++ b/src/pomo/ui.rs
@@ -34,7 +34,7 @@ pub fn render(f: &mut Frame, app: &mut Pomo) {
             };
 
             let footer = format!(
-                "tab session • t tasks • e edit time • space pause • r reset • {} • q quit",
+                "tab session • {} • t tasks • e edit time • space pause • r reset • q quit",
                 auto_switch
             );
             f.render_widget(

--- a/src/pomo/ui.rs
+++ b/src/pomo/ui.rs
@@ -27,7 +27,16 @@ pub fn render(f: &mut Frame, app: &mut Pomo) {
 
             render_timer_screen(f, app, timer_v_center[1]);
 
-            let footer = "tab session • t tasks • e edit time • space pause • r reset • q quit";
+            let auto_switch = if app.auto_switch_sessions {
+                "a next: auto"
+            } else {
+                "a next: manual"
+            };
+
+            let footer = format!(
+                "tab session • t tasks • e edit time • space pause • r reset • {} • q quit",
+                auto_switch
+            );
             f.render_widget(
                 Paragraph::new(footer)
                     .alignment(Alignment::Center)
@@ -89,83 +98,17 @@ fn format_monolithic_ascii(time: &str) -> Text<'static> {
     let mut lines = vec![String::new(); 5];
     for (idx, c) in time.chars().enumerate() {
         let art = match c {
-            '0' => vec![
-                " ██████ ", 
-                "██    ██", 
-                "██    ██", 
-                "██    ██", 
-                " ██████ "
-            ],
-            '1' => vec![
-                "   ██   ", 
-                "  ███   ", 
-                "   ██   ", 
-                "   ██   ", 
-                " ██████ "
-            ],
-            '2' => vec![
-                " ██████ ", 
-                "██    ██", 
-                "    ███ ", 
-                "  ███   ", 
-                "████████"
-            ],
-            '3' => vec![
-                " ██████ ", 
-                "      ██", 
-                "  █████ ", 
-                "      ██", 
-                " ██████ "
-            ],
-            '4' => vec![
-                "██    ██", 
-                "██    ██", 
-                "████████", 
-                "      ██", 
-                "      ██"
-            ],
-            '5' => vec![
-                "████████", 
-                "██      ", 
-                "███████ ", 
-                "      ██", 
-                "███████ "
-            ],
-            '6' => vec![
-                " ██████ ", 
-                "██      ", 
-                "███████ ", 
-                "██    ██", 
-                " ██████ "
-            ],
-            '7' => vec![
-                "████████", 
-                "      ██", 
-                "     ██ ", 
-                "    ██  ", 
-                "   ██   "
-            ],
-            '8' => vec![
-                " ██████ ", 
-                "██    ██", 
-                " ██████ ", 
-                "██    ██", 
-                " ██████ "
-            ],
-            '9' => vec![
-                " ██████ ", 
-                "██    ██", 
-                " ███████", 
-                "      ██", 
-                " ██████ "
-            ],
-            ':' => vec![
-                "        ", 
-                "   █    ", 
-                "        ", 
-                "   █    ", 
-                "        "
-            ],
+            '0' => vec![" ██████ ", "██    ██", "██    ██", "██    ██", " ██████ "],
+            '1' => vec!["   ██   ", "  ███   ", "   ██   ", "   ██   ", " ██████ "],
+            '2' => vec![" ██████ ", "██    ██", "    ███ ", "  ███   ", "████████"],
+            '3' => vec![" ██████ ", "      ██", "  █████ ", "      ██", " ██████ "],
+            '4' => vec!["██    ██", "██    ██", "████████", "      ██", "      ██"],
+            '5' => vec!["████████", "██      ", "███████ ", "      ██", "███████ "],
+            '6' => vec![" ██████ ", "██      ", "███████ ", "██    ██", " ██████ "],
+            '7' => vec!["████████", "      ██", "     ██ ", "    ██  ", "   ██   "],
+            '8' => vec![" ██████ ", "██    ██", " ██████ ", "██    ██", " ██████ "],
+            '9' => vec![" ██████ ", "██    ██", " ███████", "      ██", " ██████ "],
+            ':' => vec!["        ", "   █    ", "        ", "   █    ", "        "],
             _ => vec!["        "; 5],
         };
         for i in 0..5 {
@@ -235,7 +178,12 @@ pub fn render_task_screen(f: &mut Frame, app: &mut Pomo, footer_area: Rect) {
                 .padding(Padding::uniform(1))
                 .border_style(Style::default().fg(app.theme.primary)),
         )
-        .highlight_style(Style::default().bg(app.theme.surface0).fg(app.theme.text).bold())
+        .highlight_style(
+            Style::default()
+                .bg(app.theme.surface0)
+                .fg(app.theme.text)
+                .bold(),
+        )
         .highlight_symbol(">> ");
 
     f.render_stateful_widget(list, area, &mut app.task_state);


### PR DESCRIPTION
Fixes #4

Adds a toggle for automatic session switching.

- Press `a` to toggle automatic session switching on/off
- Current state is displayed in the footer
- Setting is persisted in the config file
- Notifications still fire when a session ends
- When disabled, sessions do not automatically advance