### PR TITLE
feat: export timer status for external integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
+<div align="center">
+
 # pomoru
 
 A minimalist Pomodoro TUI with a task list, written in Rust.
 
-`pomoru` is a keyboard-driven TUI application for focused work. It combines a Pomodoro timer with a small task manager so you can track what you’re working on without leaving the terminal.
+![Rust](https://img.shields.io/badge/Rust-Language-orange?logo=rust)
+![ratatui](https://img.shields.io/badge/ratatui-TUI-blue)
+![Tokio](https://img.shields.io/badge/Tokio-Async_Runtime-green)
+![AUR](https://img.shields.io/aur/version/pomoru?logo=arch-linux)
+![License](https://img.shields.io/badge/License-MIT-blue)
 
----
+</div>
 
 ## Features
 
 ### Timer
 
-* Work, short break, and long break sessions
-* Customizable durations
-* Desktop notifications when sessions end
+- Work, short break, and long break sessions
+- Customizable durations
+- Desktop notifications when sessions end
+- Optional automatic session switching
+- Manual session progression mode
 
 ### Tasks
 
-* Add, edit, delete tasks
-* Toggle completion
-* Task list persists across runs
+- Add, edit, delete tasks
+- Toggle completion
+- Task list persists across runs
 
 ### Design
 
-* Keyboard-only interaction
-* Minimalist interface 
-* Dynamic theming system (for Noctalia Shell users)
-* Configuration saved locally
+- Keyboard-only interaction
+- Minimalist interface
+- Dynamic theming system (for Noctalia Shell users)
+- Configuration saved locally
 
 ---
 
@@ -39,14 +47,15 @@ A minimalist Pomodoro TUI with a task list, written in Rust.
 
 ### Timer screen
 
-| Key     | Action                            |
-| ------- | --------------------------------- |
-| `space` | Start or pause timer              |
-| `tab`   | Change session type (when paused) |
-| `e`     | Edit current session time         |
-| `r`     | Reset timer                       |
-| `t`     | Open task list                    |
-| `q`     | Quit                              |
+| Key     | Action                             |
+| ------- | ---------------------------------- |
+| `space` | Start or pause timer               |
+| `tab`   | Change session type (when paused)  |
+| `a`     | Toggle automatic session switching |
+| `e`     | Edit current session time          |
+| `r`     | Reset timer                        |
+| `t`     | Open task list                     |
+| `q`     | Quit                               |
 
 ### Task screen
 
@@ -72,12 +81,12 @@ Config file location:
 
 ```text
 ~/.config/pomoru/config.toml
-````
+```
 
 Saved data includes:
 
-* Work and break durations
-* Task list
+- Work and break durations
+- Task list
 
 Example:
 
@@ -85,10 +94,54 @@ Example:
 work_time_mins = 25
 short_break_mins = 5
 long_break_mins = 15
+auto_switch_sessions = true
 
 [[tasks]]
 title = "Read documentation"
 is_done = false
+```
+
+---
+
+## Status Export
+
+Pomoru exports its current state to:
+
+```text
+~/.cache/pomoru/status.json
+```
+
+Example:
+
+```json
+{
+  "text": "󰄉 Work 24:31",
+  "tooltip": "Work",
+  "class": "work"
+}
+```
+
+This can be used by:
+
+- Waybar
+- Custom status bars
+- Shell scripts
+- Desktop widgets
+
+---
+
+### Waybar
+
+The previously stated `status.json` can be used in Waybar as follows:
+
+```json
+"custom/pomoru": {
+  "exec": "cat ~/.cache/pomoru/status.json",
+  "return-type": "json",
+  "interval": 1,
+  "format": "{text}",
+  "tooltip": true
+}
 ```
 
 ---
@@ -140,12 +193,12 @@ cargo install --path .
 
 ## Built with
 
-* Rust
-* ratatui
-* crossterm
-* tokio
-* notify-rust
-* serde + toml
+- Rust
+- ratatui
+- crossterm
+- tokio
+- notify-rust
+- serde + toml
 
 ---
 

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -28,8 +28,14 @@ impl Pomo {
             SessionMode::Work => "Work",
         };
 
+        let icon = match self.mode {
+            SessionMode::Work => "󰄉",
+            SessionMode::ShortBreak => "󰾅",
+            SessionMode::LongBreak => "󰒲",
+        };
+
         CurrentStatus {
-            text: format_duration(self.time_remaining),
+            text: format!("{icon} {tooltip} {}", format_duration(self.time_remaining)),
             tooltip: tooltip.to_string(),
             class: class.to_string(),
         }

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -35,12 +35,18 @@ impl Pomo {
         }
     }
 
-    pub fn export_status(&self) -> std::io::Result<()> {
+    pub fn export_status(&self) -> Result<(), Box<dyn std::error::Error>> {
         let status = self.current_status();
 
         let json = serde_json::to_string(&status)?;
 
-        // TODO: write to ~/.cache/pomoru/status.json
+        let cache_dir = ProjectDirs::from("", "", "pomoru")
+            .ok_or("Could not find cache directory")?
+            .cache_dir()
+            .to_path_buf();
+
+        fs::create_dir_all(&cache_dir)?;
+        fs::write(cache_dir.join("status.json"), json)?;
 
         Ok(())
     }

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -1,7 +1,10 @@
 pub mod state;
 pub mod ui;
 
-use crate::pomo::state::{AppScreen, Config, InputMode, Pomo, SessionMode, Task};
+use crate::pomo::{
+    state::{AppScreen, Config, CurrentStatus, InputMode, Pomo, SessionMode, Task},
+    ui::format_duration,
+};
 use crossterm::{
     event::{self, Event, KeyCode},
     execute,
@@ -12,6 +15,26 @@ use ratatui::prelude::*;
 use std::{fs, io, time::Duration};
 
 impl Pomo {
+    pub fn current_status(&self) -> CurrentStatus {
+        let class = match self.mode {
+            SessionMode::ShortBreak => "short-break",
+            SessionMode::LongBreak => "long-break",
+            SessionMode::Work => "work",
+        };
+
+        let tooltip = match self.mode {
+            SessionMode::ShortBreak => "Short Break",
+            SessionMode::LongBreak => "Long Break",
+            SessionMode::Work => "Work",
+        };
+
+        CurrentStatus {
+            text: format_duration(self.time_remaining),
+            tooltip: tooltip.to_string(),
+            class: class.to_string(),
+        }
+    }
+
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
         let config = Config {
             work_time_mins: self.work_time.as_secs() / 60,

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -57,6 +57,21 @@ impl Pomo {
         Ok(())
     }
 
+    pub fn clear_status(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let cache_dir = ProjectDirs::from("", "", "pomoru")
+            .ok_or("Could not find cache directory")?
+            .cache_dir()
+            .to_path_buf();
+
+        let status_file = cache_dir.join("status.json");
+
+        if status_file.exists() {
+            fs::remove_file(status_file)?;
+        }
+
+        Ok(())
+    }
+
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
         let config = Config {
             work_time_mins: self.work_time.as_secs() / 60,
@@ -129,6 +144,7 @@ impl Pomo {
 
             if self.should_quit {
                 let _ = self.save();
+                let _ = self.clear_status();
             }
         }
 

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -35,6 +35,16 @@ impl Pomo {
         }
     }
 
+    pub fn export_status(&self) -> std::io::Result<()> {
+        let status = self.current_status();
+
+        let json = serde_json::to_string(&status)?;
+
+        // TODO: write to ~/.cache/pomoru/status.json
+
+        Ok(())
+    }
+
     pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
         let config = Config {
             work_time_mins: self.work_time.as_secs() / 60,
@@ -88,6 +98,7 @@ impl Pomo {
             tokio::select! {
                 _ = second_tick.tick() => {
                     self.tick();
+                    let _ = self.export_status();
                 }
 
                 // Tighten poll to 16ms (~60fps feel) for input responsiveness

--- a/src/pomo/mod.rs
+++ b/src/pomo/mod.rs
@@ -98,6 +98,8 @@ impl Pomo {
 
         let mut second_tick = tokio::time::interval(Duration::from_secs(1));
 
+        let _ = self.export_status();
+
         while !self.should_quit {
             terminal.draw(|f| ui::render(f, self))?;
 
@@ -114,6 +116,7 @@ impl Pomo {
                         && key.kind == event::KeyEventKind::Press
                     {
                         self.handle_key(key);
+                        let _ = self.export_status();
                     }
                }
             }

--- a/src/pomo/state.rs
+++ b/src/pomo/state.rs
@@ -100,6 +100,13 @@ fn default_auto_switch() -> bool {
     true
 }
 
+#[derive(Serialize)]
+pub struct CurrentStatus {
+    pub text: String,
+    pub tooltip: String,
+    pub class: String,
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Task {
     pub title: String,


### PR DESCRIPTION
Fixes #5

Exports the current Pomoru status as JSON for use by external integrations such as Waybar, desktop widgets, shell scripts, and custom status bars.

* Add `CurrentStatus` struct
* Export status to `~/.cache/pomoru/status.json`
* Export on startup
* Export on timer updates
* Export on state changes
* Include session icon and name in exported output
* Include CSS-friendly status classes (`work`, `short-break`, `long-break`)

Example output:

```json
{
  "text": "󰄉 Work 24:31",
  "tooltip": "Work",
  "class": "work"
}
```
